### PR TITLE
Add browser-based TUI support with optional serve flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,12 @@ PaperFarm status --sparkline
 PaperFarm results --chart primary
 ```
 
-> Try the interactive demo — no agent or API key needed: `PaperFarm demo`
+> Try the interactive demo — no agent or API key needed:
+> ```bash
+> PaperFarm demo              # run in terminal
+> PaperFarm demo --serve      # open in browser at http://localhost:8000
+> PaperFarm demo --serve --port 9000
+> ```
 
 ---
 
@@ -332,7 +337,11 @@ Open Researcher supports **Linux**, **macOS**, and **Windows**. Python 3.10+ req
 pip install PaperFarm
 
 # Try the demo first (no agent or API key needed)
-PaperFarm demo
+PaperFarm demo                   # run in terminal
+PaperFarm demo --serve           # open in browser at http://localhost:8000
+
+# Install browser support (optional)
+pip install "PaperFarm[serve]"
 
 # Then use it for real
 cd your-project
@@ -373,6 +382,7 @@ make lint   # run linter
 | `start` | Legacy alias for bootstrap mode |
 | `init [--tag NAME]` | Initialize `.research/` directory |
 | `demo` | Try the TUI with sample data (no agent needed) |
+| `demo --serve [--port N]` | Serve the demo TUI in a browser (requires `PaperFarm[serve]`) |
 
 </details>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
 
 [project.optional-dependencies]
 tokens = ["tiktoken>=0.7.0"]
+serve = ["textual-serve>=1.1.0"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",

--- a/src/open_researcher/cli.py
+++ b/src/open_researcher/cli.py
@@ -211,11 +211,14 @@ def _dispatch_workflow(
 
 
 @app.command()
-def demo():
+def demo(
+    serve: bool = typer.Option(False, "--serve", help="Serve the TUI in a browser via textual-serve."),
+    port: int = typer.Option(8000, "--port", help="Port for the web server (only used with --serve)."),
+):
     """Launch the TUI with sample data — no agent or project needed."""
     from open_researcher.demo_cmd import do_demo
 
-    do_demo()
+    do_demo(serve=serve, port=port)
 
 
 @app.command()

--- a/src/open_researcher/demo_cmd.py
+++ b/src/open_researcher/demo_cmd.py
@@ -286,42 +286,88 @@ def _inject_logs(app, delay: float = 0.3) -> None:
         time.sleep(delay)
 
 
-def do_demo() -> None:
+def _setup_demo_repo(repo: Path) -> None:
+    """Initialize a minimal git repo and populate .research/ with sample data."""
+    subprocess.run(["git", "init", "--quiet"], cwd=str(repo), capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "demo@open-researcher.dev"],
+        cwd=str(repo),
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Demo"],
+        cwd=str(repo),
+        capture_output=True,
+    )
+    (repo / "train.py").write_text("# nanoGPT training script\n")
+    (repo / "model.py").write_text("# GPT model definition\n")
+    subprocess.run(["git", "add", "."], cwd=str(repo), capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial", "--quiet"],
+        cwd=str(repo),
+        capture_output=True,
+    )
+    research = repo / ".research"
+    research.mkdir()
+    _populate_research(research)
+
+
+def do_demo(serve: bool = False, port: int = 8000) -> None:
     """Launch the TUI with pre-populated sample data for a hands-on demo."""
     console.print("[bold green]Open Researcher Demo[/bold green]")
+
+    if serve:
+        try:
+            from textual_serve.server import Server
+        except ImportError:
+            console.print(
+                "[red]textual-serve is not installed.[/red]\n"
+                "Install it with: [bold]pip install open-researcher[serve][/bold]"
+            )
+            return
+
+        import atexit
+
+        tmp_obj = tempfile.TemporaryDirectory(prefix="or-demo-")
+        repo = Path(tmp_obj.name)
+        atexit.register(tmp_obj.cleanup)
+
+        _setup_demo_repo(repo)
+
+        # Write a self-contained launcher script that textual-serve can execute
+        python_exe = str(Path(__file__).parents[1] / ".." / ".." / ".venv" / "bin" / "python")
+        # Resolve to absolute path; fall back to sys.executable if venv not found
+        import sys as _sys
+
+        python_exe = str(Path(python_exe).resolve()) if Path(python_exe).exists() else _sys.executable
+
+        launcher = repo / "_serve_launcher.py"
+        launcher.write_text(
+            "import threading\n"
+            "from pathlib import Path\n"
+            "from open_researcher.tui.app import ResearchApp\n"
+            "from open_researcher.demo_cmd import _inject_logs\n"
+            f"repo_path = Path({str(repo)!r})\n"
+            "app = ResearchApp(repo_path)\n"
+            "def on_ready():\n"
+            "    t = threading.Thread(target=_inject_logs, args=(app,), daemon=True)\n"
+            "    t.start()\n"
+            "app._on_ready = on_ready\n"
+            "app.run()\n"
+        )
+
+        console.print(f"Launching TUI in browser at [bold]http://localhost:{port}[/bold]\n")
+        console.print("[dim]Press Ctrl+C to stop the server.[/dim]\n")
+        server = Server(f"{python_exe} {launcher}", port=port)
+        server.serve()
+        return
+
     console.print("Launching TUI with sample nanoGPT experiment data...\n")
 
     with tempfile.TemporaryDirectory(prefix="or-demo-") as tmp:
         repo = Path(tmp)
+        _setup_demo_repo(repo)
 
-        # Init a minimal git repo (required for git-based features)
-        subprocess.run(["git", "init", "--quiet"], cwd=str(repo), capture_output=True)
-        subprocess.run(
-            ["git", "config", "user.email", "demo@open-researcher.dev"],
-            cwd=str(repo),
-            capture_output=True,
-        )
-        subprocess.run(
-            ["git", "config", "user.name", "Demo"],
-            cwd=str(repo),
-            capture_output=True,
-        )
-        # Create a dummy file and initial commit
-        (repo / "train.py").write_text("# nanoGPT training script\n")
-        (repo / "model.py").write_text("# GPT model definition\n")
-        subprocess.run(["git", "add", "."], cwd=str(repo), capture_output=True)
-        subprocess.run(
-            ["git", "commit", "-m", "initial", "--quiet"],
-            cwd=str(repo),
-            capture_output=True,
-        )
-
-        # Populate .research/ with sample data
-        research = repo / ".research"
-        research.mkdir()
-        _populate_research(research)
-
-        # Launch TUI
         from open_researcher.tui.app import ResearchApp
 
         def on_ready():


### PR DESCRIPTION
This pull request adds browser-based demo support for the Open Researcher TUI, allowing users to run the demo in their terminal or serve it in a browser using the new `--serve` flag. The documentation and codebase have been updated to clarify usage and to support this feature, including the addition of an optional dependency for browser serving.

**Demo feature enhancements:**

* Added `--serve` and `--port` options to the `demo` CLI command in `cli.py`, enabling users to launch the TUI demo in a browser via `textual-serve`.
* Refactored `demo_cmd.py`: split demo repo setup into `_setup_demo_repo`, and updated `do_demo` to handle both terminal and browser serving modes, including writing a launcher script for `textual-serve` and handling missing dependencies gracefully. [[1]](diffhunk://#diff-262856271412a55b06f3faf851c87ec8fc25da81ff6520c6713ef40a8c782a79L289-R290) [[2]](diffhunk://#diff-262856271412a55b06f3faf851c87ec8fc25da81ff6520c6713ef40a8c782a79L318-R370)

**Documentation updates:**

* Expanded demo instructions in `README.md` to show how to run the demo in terminal or browser, and clarified installation of browser support. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L335-R344) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L102-R107)
* Updated command reference table in `README.md` to include browser serving options for the demo command.

**Dependency management:**

* Added an optional `serve` dependency (`textual-serve>=1.1.0`) in `pyproject.toml` for browser-based demo support.Introduce an optional `--serve` flag to the `demo` command that launches the research TUI in a browser using textual-serve, enabling use without a local terminal emulator.

- Add `serve` optional dependency group in pyproject.toml (`pip install open-researcher[serve]`)
- Refactor demo_cmd.py: extract `_setup_demo_repo()` helper and extend `do_demo()` with `serve: bool` and `port: int` parameters; generate a self-contained launcher script consumed by textual-serve's Server
- Extend CLI `demo` command with `--serve` and `--port` options
- Update README to document terminal vs browser usage and the new optional dependency

## Summary

<!-- What does this PR do? 1-2 sentences. -->

## Changes

<!-- Bulleted list of key changes. -->

-

## Test plan

<!-- How was this tested? -->

- [ ] `make test` passes
- [ ] `make lint` passes
- [ ] New tests added for new functionality

## Related issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
