### PR TITLE
refactor: thin run/headless entrypoints via shared helpers

### DIFF
--- a/src/open_researcher/headless.py
+++ b/src/open_researcher/headless.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from open_researcher.agent_runtime import resolve_agent
-from open_researcher.bootstrap import ensure_bootstrap_state, run_bootstrap_prepare
+from open_researcher.bootstrap import run_bootstrap_prepare
 from open_researcher.event_journal import EventJournal
-from open_researcher.graph_protocol import initialize_graph_runtime_state
 from open_researcher.research_events import (
     ReviewAutoConfirmed,
     RoleFailed,
@@ -32,6 +31,7 @@ from open_researcher.runtime_entrypoints import (
     load_runtime_config,
     resolve_research_agents,
     resolve_scout_agent,
+    sync_runtime_state,
 )
 
 _resolve_agent = resolve_agent
@@ -114,8 +114,7 @@ def do_run_headless(
         raise SystemExit(1)
 
     cfg = load_runtime_config(research, workers=workers, max_experiments=max_experiments, token_budget=token_budget)
-    initialize_graph_runtime_state(research, cfg)
-    ensure_bootstrap_state(research / "bootstrap_state.json")
+    sync_runtime_state(research, cfg)
     effective_max = cfg.max_experiments
 
     logger = HeadlessLogger(stream=stream, log_path=research / "events.jsonl")
@@ -194,8 +193,7 @@ def do_start_headless(
 
     research = do_start_init(repo_path, tag=tag)
     cfg = load_runtime_config(research, workers=workers, max_experiments=max_experiments, token_budget=token_budget)
-    initialize_graph_runtime_state(research, cfg)
-    ensure_bootstrap_state(research / "bootstrap_state.json")
+    sync_runtime_state(research, cfg)
 
     effective_max = cfg.max_experiments
 
@@ -244,7 +242,7 @@ def do_start_headless(
             max_experiments=max_experiments,
             token_budget=token_budget,
         )
-        initialize_graph_runtime_state(research, cfg)
+        sync_runtime_state(research, cfg)
         prepare_code, _state = run_bootstrap_prepare(
             repo_path,
             research,

--- a/src/open_researcher/run_cmd.py
+++ b/src/open_researcher/run_cmd.py
@@ -16,7 +16,6 @@ from open_researcher.bootstrap import (
     format_bootstrap_dry_run,
     run_bootstrap_prepare,
 )
-from open_researcher.graph_protocol import initialize_graph_runtime_state
 from open_researcher.research_loop import (
     ResearchLoop,
 )
@@ -35,6 +34,7 @@ from open_researcher.runtime_entrypoints import (
     load_runtime_config,
     resolve_research_agents,
     resolve_scout_agent,
+    sync_runtime_state,
 )
 from open_researcher.tui_runner import (
     print_exit_summary,
@@ -151,8 +151,7 @@ def do_run(
         raise SystemExit(1)
 
     cfg = load_runtime_config(research, workers=workers, max_experiments=max_experiments, token_budget=token_budget)
-    initialize_graph_runtime_state(research, cfg)
-    ensure_bootstrap_state(research / "bootstrap_state.json")
+    sync_runtime_state(research, cfg)
     manager_agent, critic_agent, exp_agent = resolve_research_agents(
         cfg,
         primary_agent_name=agent_name,
@@ -254,8 +253,7 @@ def do_start(
         tag = date.today().strftime("%b%d").lower()
     research = do_start_init(repo_path, tag=tag)
     cfg = load_runtime_config(research, workers=workers, max_experiments=max_experiments, token_budget=token_budget)
-    initialize_graph_runtime_state(research, cfg)
-    ensure_bootstrap_state(research / "bootstrap_state.json")
+    sync_runtime_state(research, cfg)
 
     scout_agent = resolve_scout_agent(
         cfg,
@@ -300,8 +298,7 @@ def do_start(
                 refreshed_cfg = load_runtime_config(
                     research, workers=workers, max_experiments=max_experiments, token_budget=token_budget
                 )
-                initialize_graph_runtime_state(research, refreshed_cfg)
-                ensure_bootstrap_state(research / "bootstrap_state.json")
+                sync_runtime_state(research, refreshed_cfg)
                 cfg_ref["cfg"] = refreshed_cfg
                 loop.cfg = refreshed_cfg
                 prepare_code, _ = run_bootstrap_prepare(

--- a/src/open_researcher/runtime_entrypoints.py
+++ b/src/open_researcher/runtime_entrypoints.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from open_researcher.bootstrap import ensure_bootstrap_state
 from open_researcher.config import load_config, require_supported_protocol
-from open_researcher.graph_protocol import resolve_role_agent_name
+from open_researcher.graph_protocol import initialize_graph_runtime_state, resolve_role_agent_name
 from open_researcher.parallel_runtime import run_parallel_experiment_batch
 from open_researcher.workflow_options import apply_worker_override
 
@@ -81,3 +82,9 @@ def build_parallel_runner(
         on_output,
         **kwargs,
     )
+
+
+def sync_runtime_state(research: Path, cfg) -> None:
+    """Ensure graph and bootstrap runtime artifacts are initialized."""
+    initialize_graph_runtime_state(research, cfg)
+    ensure_bootstrap_state(research / "bootstrap_state.json")

--- a/tests/test_runtime_entrypoints.py
+++ b/tests/test_runtime_entrypoints.py
@@ -13,6 +13,7 @@ from open_researcher.runtime_entrypoints import (
     load_runtime_config,
     resolve_research_agents,
     resolve_scout_agent,
+    sync_runtime_state,
 )
 
 
@@ -153,3 +154,25 @@ def test_build_parallel_runner_calls_parallel_runtime(monkeypatch, tmp_path):
     assert captured["exp_agent"] is exp_agent
     assert captured["on_output"] is on_output
     assert captured["kwargs"] == {"batch_id": "test"}
+
+
+def test_sync_runtime_state_initializes_graph_and_bootstrap(monkeypatch, tmp_path):
+    research = tmp_path / ".research"
+    research.mkdir()
+    cfg = SimpleNamespace(mode="autonomous")
+    calls: dict[str, object] = {}
+
+    def fake_init_graph(research_dir, cfg_obj):
+        calls["init_graph"] = (research_dir, cfg_obj)
+        return {}
+
+    def fake_ensure_bootstrap(path):
+        calls["ensure_bootstrap"] = path
+
+    monkeypatch.setattr("open_researcher.runtime_entrypoints.initialize_graph_runtime_state", fake_init_graph)
+    monkeypatch.setattr("open_researcher.runtime_entrypoints.ensure_bootstrap_state", fake_ensure_bootstrap)
+
+    sync_runtime_state(research, cfg)
+
+    assert calls["init_graph"] == (research, cfg)
+    assert calls["ensure_bootstrap"] == research / "bootstrap_state.json"


### PR DESCRIPTION
## Summary
- extract shared run/headless entrypoint helpers into runtime_entrypoints.py
- remove duplicated role-agent resolution, runtime config loading, and parallel runner wiring from both entrypoints
- keep run_cmd.py focused on interactive flow orchestration while preserving existing behavior
- align headless config refresh path to reuse the same loader (including token budget override)
- add shared runtime-state sync helper and apply it across run/headless flows

## Tests
- .venv/bin/ruff check src/open_researcher/runtime_entrypoints.py src/open_researcher/run_cmd.py src/open_researcher/headless.py tests/test_runtime_entrypoints.py
- .venv/bin/pytest tests/ -q

Closes #33