### PR TITLE
ci: strengthen quality gates and packaging checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,45 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  COVERAGE_MIN: "75"
+
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Lint
+        run: make lint
+
+  test:
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
@@ -21,14 +56,71 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      - name: Lint
-        run: make lint
-
       - name: Test
-        run: pytest tests/ -v
+        run: pytest tests/ -q
+
+  coverage:
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Coverage
+        run: |
+          pytest tests/ \
+            --cov=open_researcher \
+            --cov-report=term-missing \
+            --cov-report=xml \
+            --cov-fail-under=${COVERAGE_MIN}
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+
+  package-smoke:
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Build and install wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+          pip install dist/*.whl
+
+      - name: Smoke CLI entrypoint
+        run: open-researcher --help > /dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 .eggs/
 *.egg
 .venv/
+.venv-pf/
 venv/
 env/
 .pytest_cache/
@@ -14,6 +15,7 @@ env/
 .mypy_cache/
 htmlcov/
 .coverage
+coverage.xml
 *.log
 .DS_Store
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ make dev
 
 ```bash
 make test
+make test-cov
+make package-check
 ```
 
 ## Code Style
@@ -39,4 +41,4 @@ make format  # auto-fix
 
 - One feature per PR
 - Include tests
-- Run `make lint && make test` before submitting
+- Run `make ci` before submitting

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dev test lint clean
+.PHONY: install dev test test-cov lint package-check ci clean
 
 install:
 	pip install -e .
@@ -9,6 +9,9 @@ dev:
 test:
 	pytest tests/ -v
 
+test-cov:
+	pytest tests/ --cov=open_researcher --cov-report=term-missing --cov-fail-under=75
+
 lint:
 	ruff check src/ tests/
 
@@ -16,6 +19,18 @@ format:
 	ruff check --fix src/ tests/
 	ruff format src/ tests/
 
+package-check:
+	python -m pip install --upgrade pip build
+	python -m build
+	python -m pip install --force-reinstall dist/*.whl
+	open-researcher --help > /dev/null
+
+ci:
+	$(MAKE) lint
+	$(MAKE) test
+	$(MAKE) test-cov
+	$(MAKE) package-check
+
 clean:
-	rm -rf dist/ build/ *.egg-info .pytest_cache .ruff_cache htmlcov
+	rm -rf dist/ build/ *.egg-info .pytest_cache .ruff_cache htmlcov .coverage coverage.xml
 	find . -type d -name __pycache__ -exec rm -rf {} +

--- a/README.md
+++ b/README.md
@@ -370,7 +370,10 @@ git clone https://github.com/shatianming5/PaperFarm.git
 cd PaperFarm
 make dev    # install with dev dependencies
 make test   # run tests
+make test-cov      # run tests with coverage gate (>=75%)
 make lint   # run linter
+make package-check # build wheel + install + CLI smoke test
+make ci     # full local CI: lint + test + coverage + package smoke
 ```
 
 </details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ serve = ["textual-serve>=1.1.0"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
+    "pytest-cov>=5.0",
     "ruff>=0.4.0",
 ]
 


### PR DESCRIPTION
## Summary
- split CI into focused `lint`, matrix `test`, `coverage`, and `package-smoke` jobs
- add workflow concurrency cancellation, pip cache, timeout limits, and coverage artifact upload
- add a 75% coverage gate with `pytest-cov` and align local dev commands/docs (`make ci`, `make test-cov`, `make package-check`)
- ignore local `.venv-pf/` and `coverage.xml` to keep packaging and git status clean

## Validation
- `ruff check src/ tests/`
- `pytest tests/ -q`
- `pytest tests/ --cov=open_researcher --cov-report=term --cov-fail-under=75 -q`
- `make ci`
