### PR TITLE
ci: auto-trigger @codex review for every PR

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,42 @@
+name: Codex Review Request
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  request-codex-review:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post @codex request once per PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- codex-auto-review-trigger -->';
+            const issue_number = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            if (comments.some((comment) => comment.body && comment.body.includes(marker))) {
+              core.info('Codex review trigger comment already exists. Skipping.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: `${marker}\n@codex review`,
+            });


### PR DESCRIPTION
## Summary
- add a dedicated workflow to request Codex review on each non-draft PR
- trigger on pull_request_target for opened/reopened/ready_for_review events
- deduplicate comments with a hidden marker to avoid repeated bot spam

## Verification
- workflow syntax reviewed locally
- dedupe logic validated by code path inspection

Closes #23