### PR TITLE
docs: add bilingual EN/ZH core docs and clean metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,44 +1,68 @@
-# Contributing to Open Researcher
+# Contributing to PaperFarm
 
-Thanks for your interest in contributing!
+[English](CONTRIBUTING.md) · [简体中文](CONTRIBUTING.zh-CN.md)
+
+Thanks for your interest in contributing.
+
+## Before You Start
+
+- Prefer **issue first, PR second** for non-trivial changes.
+- Keep changes scoped: one feature/fix per PR.
+- If behavior changes, update docs and add/adjust tests in the same PR.
 
 ## Development Setup
 
 ```bash
-git clone https://github.com/open-researcher/open-researcher.git
-cd open-researcher
+git clone https://github.com/shatianming5/PaperFarm.git
+cd PaperFarm
 python -m venv .venv
 source .venv/bin/activate
 make dev
 ```
 
-## Running Tests
+## Local Checks
 
 ```bash
+make lint
 make test
 make test-cov
 make package-check
+make ci
 ```
+
+`make ci` is the expected pre-PR baseline.
+
+## Pull Request Checklist
+
+- Clear PR title and description (what changed and why)
+- Linked issue (for non-trivial changes)
+- Tests updated or added when behavior changes
+- Docs updated when UX/CLI/config/contracts change
+- No unrelated refactors mixed into the same PR
+
+## Documentation Policy
+
+Core contributor-facing docs should stay bilingual (EN/ZH):
+
+- `README.md` / `README.zh-CN.md`
+- `CONTRIBUTING.md` / `CONTRIBUTING.zh-CN.md`
+- `docs/README.md` / `docs/README.zh-CN.md`
+
+Historical plan docs under `docs/plans/` are archived and not the canonical interface contract.
 
 ## Code Style
 
-We use [ruff](https://github.com/astral-sh/ruff) for linting and formatting:
+We use [ruff](https://github.com/astral-sh/ruff) for linting/formatting.
 
 ```bash
-make lint    # check
-make format  # auto-fix
+make lint
+make format
 ```
 
 ## Adding a New Agent Adapter
 
-1. Create `src/open_researcher/agents/your_agent.py`
-2. Implement the `AgentAdapter` interface (see `base.py`)
-3. Add the `@register` decorator
+1. Add `src/open_researcher/agents/<agent>.py`
+2. Implement `AgentAdapter` (see `src/open_researcher/agents/base.py`)
+3. Register adapter via `@register`
 4. Add tests in `tests/test_agents.py`
-5. Update the agent table in `README.md`
-
-## Pull Requests
-
-- One feature per PR
-- Include tests
-- Run `make ci` before submitting
+5. Update agent docs in `README.md` and `README.zh-CN.md`

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -1,0 +1,68 @@
+# 贡献指南（PaperFarm）
+
+[English](CONTRIBUTING.md) · [简体中文](CONTRIBUTING.zh-CN.md)
+
+感谢你参与 PaperFarm 的建设。
+
+## 开始之前
+
+- 对于非小改动，建议 **先 Issue、后 PR**。
+- 每个 PR 保持单一目标，避免把无关重构混进来。
+- 只要行为有变化，请同时更新测试与文档。
+
+## 开发环境
+
+```bash
+git clone https://github.com/shatianming5/PaperFarm.git
+cd PaperFarm
+python -m venv .venv
+source .venv/bin/activate
+make dev
+```
+
+## 本地校验
+
+```bash
+make lint
+make test
+make test-cov
+make package-check
+make ci
+```
+
+提交 PR 前至少应通过 `make ci`。
+
+## PR 自检清单
+
+- 标题与描述清晰（改了什么、为什么）
+- 非小改动关联对应 Issue
+- 行为变化有测试覆盖
+- UX/CLI/配置/契约变化同步更新文档
+- 同一 PR 不混入无关重构
+
+## 文档策略
+
+核心对外文档应保持中英双语：
+
+- `README.md` / `README.zh-CN.md`
+- `CONTRIBUTING.md` / `CONTRIBUTING.zh-CN.md`
+- `docs/README.md` / `docs/README.zh-CN.md`
+
+`docs/plans/` 下文档属于历史归档，不作为当前对外契约。
+
+## 代码风格
+
+项目使用 [ruff](https://github.com/astral-sh/ruff) 做 lint/format。
+
+```bash
+make lint
+make format
+```
+
+## 新增 Agent 适配器
+
+1. 新建 `src/open_researcher/agents/<agent>.py`
+2. 实现 `AgentAdapter`（见 `src/open_researcher/agents/base.py`）
+3. 使用 `@register` 注册
+4. 在 `tests/test_agents.py` 增加测试
+5. 同步更新 `README.md` 与 `README.zh-CN.md` 中的 agent 说明

--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@
 
 <p><em>🌱 Sow ideas. 🚜 Run experiments. 🌾 Harvest evidence. 📄</em></p>
 
+[**English**](README.md) · [**简体中文**](README.zh-CN.md)
+
 [**Quick Start**](#-quick-start) · [**How It Works**](#-how-it-works) · [**Agents**](#-supported-agents) · [**TUI Dashboard**](#-interactive-tui-dashboard) · [**CLI Reference**](#%EF%B8%8F-cli-reference) · [**Configuration**](#%EF%B8%8F-configuration) · [**Examples**](#-examples)
 
 </div>
 
 ---
+
+> CLI entrypoint: `open-researcher` (alias: `PaperFarm`).
 
 ## 🌾 Key Features
 
@@ -589,6 +593,17 @@ See [`examples/`](examples/) for complete setups:
 
 ---
 
+## 📚 Documentation
+
+- [README.md](README.md) (English)
+- [README.zh-CN.md](README.zh-CN.md) (简体中文)
+- [CONTRIBUTING.md](CONTRIBUTING.md) (English)
+- [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md) (简体中文)
+- [docs/README.md](docs/README.md) (documentation index, English)
+- [docs/README.zh-CN.md](docs/README.zh-CN.md) (文档索引，简体中文)
+
+---
+
 ## 🧑‍🌾 Contributing
 
 Contributions are welcome! Please follow these steps:
@@ -597,7 +612,7 @@ Contributions are welcome! Please follow these steps:
 2. Fork the repository and create your feature branch
 3. Submit a pull request with a clear description
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and [CHANGELOG.md](CHANGELOG.md) for version history.
+See [CONTRIBUTING.md](CONTRIBUTING.md) / [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md) for contribution guidelines and [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## 📄 License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,90 @@
+<div align="center">
+
+# 🧑‍🌾 PaperFarm：种下想法，自动实验，收获结果
+
+[**English**](README.md) · [**简体中文**](README.zh-CN.md)
+
+</div>
+
+> CLI 入口命令：`open-researcher`（兼容别名：`PaperFarm`）
+
+## 项目简介
+
+PaperFarm 是一个面向任意 Git 仓库的自动化研究/实验框架。它会在仓库内维护 `.research/` 运行目录，通过 `Scout -> Manager -> Critic -> Experiment` 循环持续提出假设、执行实验、记录证据并回写结论。
+
+## 快速开始
+
+```bash
+pip install PaperFarm
+
+cd your-project
+open-researcher run
+# 或者使用等价别名
+PaperFarm run
+```
+
+`run` 会自动进入以下流程：
+
+1. `Scout`：分析代码、整理相关工作、定义评估方案
+2. `Prepare`：自动解析并执行 install/data/smoke 准备步骤
+3. `Review`：在 TUI 中确认研究方向（headless 模式自动确认）
+4. `Experiment`：进入 research-v1 循环并持续迭代
+
+如需只查看将要执行的流程：
+
+```bash
+open-researcher run --dry-run
+open-researcher doctor
+```
+
+## 无界面模式（Headless）
+
+```bash
+open-researcher run --mode headless --goal "reduce val_loss below 0.3" --max-experiments 20
+```
+
+Headless 会输出 JSON Lines，并写入 `.research/events.jsonl`。交互模式与 headless 共享同一条 canonical 事件流。
+
+## 常用命令
+
+```bash
+open-researcher init
+open-researcher run --agent codex
+open-researcher run --workers 4
+open-researcher status --sparkline
+open-researcher results --chart primary
+open-researcher export
+open-researcher doctor
+```
+
+## 安装与开发
+
+```bash
+git clone https://github.com/shatianming5/PaperFarm.git
+cd PaperFarm
+python -m venv .venv
+source .venv/bin/activate
+make dev
+make ci
+```
+
+## 文档导航
+
+- [README.md](README.md)（English）
+- [CONTRIBUTING.md](CONTRIBUTING.md) / [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md)
+- [docs/README.md](docs/README.md)（English 文档索引）
+- [docs/README.zh-CN.md](docs/README.zh-CN.md)（中文文档索引）
+
+## 贡献
+
+欢迎贡献，推荐流程：
+
+1. 先开 Issue 讨论方向
+2. 在独立分支开发并补充测试/文档
+3. 发起 PR，并说明行为变化与验证方式
+
+详细规范见 [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md)。
+
+## 许可证
+
+本项目使用 [MIT License](LICENSE)。

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,25 @@
+# Documentation Guide
+
+[English](README.md) · [简体中文](README.zh-CN.md)
+
+This folder contains canonical architecture/runtime documents and historical planning records.
+
+## Canonical Docs
+
+- [architecture-review.md](architecture-review.md) (ZH)
+- [architecture-review.en.md](architecture-review.en.md) (EN summary)
+- [repo_inventory.md](repo_inventory.md) (ZH)
+- [repo_inventory.en.md](repo_inventory.en.md) (EN)
+
+These files define the current architecture understanding and repository/runtime boundaries.
+
+## Historical Plans
+
+- [plans/](plans/) contains historical design and implementation plans.
+- Plan files are archived context and may not match current behavior.
+- For current behavior, treat canonical docs and source code as the authority.
+
+## Related Top-Level Docs
+
+- [../README.md](../README.md) / [../README.zh-CN.md](../README.zh-CN.md)
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) / [../CONTRIBUTING.zh-CN.md](../CONTRIBUTING.zh-CN.md)

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,0 +1,25 @@
+# 文档索引
+
+[English](README.md) · [简体中文](README.zh-CN.md)
+
+该目录包含当前生效的架构/运行时文档，以及历史计划归档。
+
+## 当前生效文档（Canonical）
+
+- [architecture-review.md](architecture-review.md)（中文）
+- [architecture-review.en.md](architecture-review.en.md)（英文摘要）
+- [repo_inventory.md](repo_inventory.md)（中文）
+- [repo_inventory.en.md](repo_inventory.en.md)（英文）
+
+上述文档用于描述当前架构认知与仓库/运行时边界。
+
+## 历史计划归档
+
+- [plans/](plans/) 下是历史设计与实施计划。
+- 历史计划可能与当前实现不一致。
+- 遇到冲突时，以 canonical 文档与源码行为为准。
+
+## 相关根目录文档
+
+- [../README.md](../README.md) / [../README.zh-CN.md](../README.zh-CN.md)
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) / [../CONTRIBUTING.zh-CN.md](../CONTRIBUTING.zh-CN.md)

--- a/docs/architecture-review.en.md
+++ b/docs/architecture-review.en.md
@@ -1,0 +1,55 @@
+# Architecture Review (English Summary)
+
+[English Summary](architecture-review.en.md) · [简体中文](architecture-review.md)
+
+## Scope
+
+This is an English summary of the full Chinese architecture review in `architecture-review.md`.
+
+## Core Conclusion
+
+The business loop is conceptually simple, but runtime/orchestration can become heavy if not isolated:
+
+- Core loop: `Scout -> Manager -> Critic -> Experiment`
+- Desired layering: `orchestration` / `runtime` / `presentation`
+
+## Implemented Progress (as of 2026-03-10)
+
+P0/P1/P2 recommendations were largely implemented:
+
+- `research_loop.py` extracted as core loop
+- typed events unified for TUI and headless
+- CLI surface simplified to higher-level concepts (`mode`, `workers`, `goal`)
+- default backlog path simplified (`IdeaBacklog` vs parallel `IdeaPool`)
+- advanced runtime features isolated behind parallel/runtime profiles
+- `events.jsonl` is canonical runtime/control stream; `control.json` is compatibility snapshot
+
+## Remaining Priorities
+
+### R1
+
+- Continue thinning `run_cmd.py` adapter/lifecycle responsibilities
+- Further internalize role-program concepts (reduce external cognitive surface)
+
+### R2
+
+- Keep advanced runtime profile/observability boundaries explicit
+- Reduce doc drift between current canonical behavior and historical plans
+
+## Current Architectural Shape
+
+### Default path (single worker)
+
+`CLI adapters -> ResearchLoop -> typed events -> TUI/Headless renderers`
+
+### Advanced path (`workers > 1`)
+
+`parallel_runtime -> WorkerManager -> runtime plugins -> IdeaPool claim/token flow`
+
+## Documentation Contract
+
+When historical plan docs conflict with implementation snapshots:
+
+1. treat source code behavior as authoritative
+2. treat canonical docs (`architecture-review.*`, `repo_inventory.*`) as current intent
+3. treat `docs/plans/` as historical archive

--- a/docs/architecture-review.md
+++ b/docs/architecture-review.md
@@ -1,5 +1,7 @@
 # 架构审查报告（GPT-5.4 + Claude Opus 4.6 联合分析）
 
+> [English Summary](architecture-review.en.md) · [简体中文](architecture-review.md)
+
 > 分析日期：2026-03-10
 > 分析工具：Codex CLI (gpt-5.4, read-only, reasoning effort: xhigh)
 

--- a/docs/repo_inventory.en.md
+++ b/docs/repo_inventory.en.md
@@ -1,0 +1,88 @@
+> [English](repo_inventory.en.md) · [简体中文](repo_inventory.md)
+
+## Tree
+- `src/open_researcher/`: main source code
+- `src/open_researcher/agents/`: agent adapters
+- `src/open_researcher/tui/`: Textual TUI
+- `src/open_researcher/scripts/`: runtime helper scripts
+- `tests/`: pytest test suite
+- `docs/`: documentation and plans
+- `examples/`: target-repo examples
+- `analysis/`: analysis notes
+- `.research/`: runtime state directory
+
+## Entry Points
+- `pyproject.toml`: exposes `open-researcher` (primary) and `PaperFarm` (compat alias) CLI entrypoints
+- `src/open_researcher/cli.py`: main CLI (`run/init/status/results/export/doctor/demo`)
+- `src/open_researcher/run_cmd.py`: interactive bootstrap/TUI path
+- `src/open_researcher/headless.py`: headless bootstrap/JSONL path
+- `src/open_researcher/init_cmd.py`: `.research/` template/state initialization
+- `src/open_researcher/config_cmd.py`: `open-researcher config show|validate`
+- `src/open_researcher/ideas_cmd.py`: `open-researcher ideas list|add|delete|prioritize`
+- `src/open_researcher/logs_cmd.py`: `open-researcher logs`
+
+## Core Modules
+- `src/open_researcher/workflow_options.py`: normalizes CLI options into interactive/headless + worker topology
+- `src/open_researcher/agent_runtime.py`: agent auto-detection and explicit resolution
+- `src/open_researcher/research_loop.py`: core `Scout -> Manager -> Critic -> Experiment` orchestration
+- `src/open_researcher/research_events.py`: typed event contract mapped to `events.jsonl`
+- `src/open_researcher/event_journal.py`: JSONL event write/read helpers
+- `src/open_researcher/graph_protocol.py`: `research-v1` init and role-agent resolution
+- `src/open_researcher/research_graph.py`: canonical hypothesis/evidence/frontier graph
+- `src/open_researcher/research_memory.py`: repo prior / ideation / experiment memory
+- `src/open_researcher/parallel_runtime.py`: parallel worker runtime
+- `src/open_researcher/tui/app.py`: interactive monitoring UI
+- `src/open_researcher/tui/events.py`: typed event to TUI log rendering
+- `src/open_researcher/status_cmd.py`: `.research/` progress/status summary
+- `src/open_researcher/results_cmd.py`: load/print/chart `results.tsv`
+
+## Config & Runtime Data
+- Config file: `.research/config.yaml`
+- Key config fields:
+  - `experiment.max_experiments`
+  - `experiment.max_parallel_workers`
+  - `metrics.primary.name`
+  - `metrics.primary.direction`
+  - `research.protocol = research-v1`
+  - `research.manager_batch_size`
+  - `research.critic_repro_policy`
+  - `roles.scout_agent|manager_agent|critic_agent|experiment_agent`
+  - `memory.ideation|experiment|repo_type_prior`
+- Runtime files:
+  - `.research/scout_program.md`
+  - `.research/.internal/role_programs/manager.md`
+  - `.research/.internal/role_programs/critic.md`
+  - `.research/.internal/role_programs/experiment.md`
+  - `.research/idea_pool.json`
+  - `.research/results.tsv`
+  - `.research/events.jsonl`
+  - `.research/research_graph.json`
+  - `.research/research_memory.json`
+  - `.research/activity.json`
+  - `.research/control.json`
+  - `.research/gpu_status.json`
+- External prerequisites:
+  - must run inside a git repository
+  - at least one supported agent CLI: `claude-code` / `codex` / `aider` / `opencode` / `kimi-cli` / `gemini-cli`
+  - parallel workers assume local or remote GPU availability when enabled, but GPU is not globally required
+
+## How To Run
+```bash
+open-researcher init
+open-researcher run --agent codex
+open-researcher run --mode headless --goal "improve latency"
+open-researcher run --agent codex --workers 1
+open-researcher run --agent codex --workers 4
+open-researcher status
+open-researcher results
+open-researcher results --chart primary
+open-researcher export
+open-researcher config show
+open-researcher ideas list
+pytest -q
+```
+
+## Risks / Unknowns
+- Current external interface is CLI + config + runtime files + typed events (not HTTP service).
+- `research-v1` is the only execution protocol, but parallel worker flows still use `idea_pool.json` as a compatibility projection.
+- Both TUI and headless consume the same typed event stream; graph tracing is fully visible under `research-v1`.

--- a/docs/repo_inventory.md
+++ b/docs/repo_inventory.md
@@ -1,3 +1,5 @@
+> [English](repo_inventory.en.md) · [简体中文](repo_inventory.md)
+
 ## Tree
 - `src/open_researcher/`: 主代码
 - `src/open_researcher/agents/`: agent adapter 实现
@@ -10,7 +12,7 @@
 - `.research/`: 运行期状态目录
 
 ## Entry Points
-- `pyproject.toml`: 暴露 `open-researcher = open_researcher.cli:app`
+- `pyproject.toml`: 暴露 `open-researcher`（主命令）与 `PaperFarm`（兼容别名）CLI entrypoints
 - `src/open_researcher/cli.py`: 主 CLI，包含 `run/init/status/results/export/doctor/demo`
 - `src/open_researcher/run_cmd.py`: interactive bootstrap/TUI 主路径
 - `src/open_researcher/headless.py`: headless bootstrap/JSONL 主路径

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,11 +50,12 @@ dev = [
 
 [project.scripts]
 open-researcher = "open_researcher.cli:app"
+PaperFarm = "open_researcher.cli:app"
 
 [project.urls]
-Homepage = "https://github.com/open-researcher/open-researcher"
-Repository = "https://github.com/open-researcher/open-researcher"
-Issues = "https://github.com/open-researcher/open-researcher/issues"
+Homepage = "https://github.com/shatianming5/PaperFarm"
+Repository = "https://github.com/shatianming5/PaperFarm"
+Issues = "https://github.com/shatianming5/PaperFarm/issues"
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
## Summary
- add bilingual core contributor docs:
  - README.md + README.zh-CN.md
  - CONTRIBUTING.md + CONTRIBUTING.zh-CN.md
  - docs/README.md + docs/README.zh-CN.md
- add English companion docs for canonical architecture/inventory:
  - docs/architecture-review.en.md
  - docs/repo_inventory.en.md
- add language cross-links in canonical docs
- fix metadata inconsistencies:
  - add PaperFarm CLI alias entrypoint in pyproject
  - update project homepage/repository/issues URLs

## Verification
- installed editable package locally
- verified CLI entrypoints:
  - .venv/bin/open-researcher --help
  - .venv/bin/PaperFarm --help

Closes #29